### PR TITLE
Rearrange fields in tree for a more compact struct

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -12,13 +12,11 @@ import (
 // builder type, then generate an immutable version). After lazy insertions,
 // the tree can be compressed using the compress() method.
 type tree[T any] struct {
-	key   key
-	value T
-	left  *tree[T]
-	right *tree[T]
-
-	// Not every node stores a value; some nodes are just shared prefixes
+	key      key
 	hasEntry bool
+	value    T
+	left     *tree[T]
+	right    *tree[T]
 }
 
 // newTree returns a new tree with the provided key.


### PR DESCRIPTION
This leads to a 23% reduction in memory footprint in the [iprbench](https://github.com/gaissmai/iprbench) size test.
```

goos: linux
goarch: amd64
cpu: AMD EPYC 7R32
                         │ netipds/size.bm │       netipds/size_packtree.bm       │
                         │        bytes         │     bytes      vs base               │
Tier1PfxSize/100                  16.83Ki ± 10%   13.81Ki ± 12%  -17.92% (p=0.002 n=6)
Tier1PfxSize/1_000               128.26Ki ±  1%   97.04Ki ±  2%  -24.34% (p=0.002 n=6)
Tier1PfxSize/10_000              1249.9Ki ±  0%   938.3Ki ±  0%  -24.93% (p=0.002 n=6)
Tier1PfxSize/100_000             11.992Mi ±  0%   8.995Mi ±  0%  -24.99% (p=0.002 n=6)
Tier1PfxSize/1_000_000           112.77Mi ±  0%   84.58Mi ±  0%  -25.00% (p=0.002 n=6)
RandomPfx4Size/100                16.20Ki ± 10%   13.09Ki ± 13%  -19.19% (p=0.002 n=6)
RandomPfx4Size/1_000             127.76Ki ±  1%   96.52Ki ±  2%  -24.45% (p=0.002 n=6)
RandomPfx4Size/10_000            1223.9Ki ±  0%   918.9Ki ±  0%  -24.93% (p=0.002 n=6)
RandomPfx4Size/100_000           10.997Mi ±  0%   8.257Mi ±  0%  -24.91% (p=0.002 n=6)
RandomPfx4Size/1_000_000          92.42Mi ±  0%   69.31Mi ±  0%  -25.00% (p=0.002 n=6)
RandomPfx6Size/100                16.14Ki ± 10%   13.05Ki ± 13%  -19.17% (p=0.002 n=6)
RandomPfx6Size/1_000             127.88Ki ±  1%   96.80Ki ±  2%  -24.30% (p=0.002 n=6)
RandomPfx6Size/10_000            1237.7Ki ±  0%   929.5Ki ±  0%  -24.90% (p=0.002 n=6)
RandomPfx6Size/100_000           11.784Mi ±  0%   8.832Mi ±  0%  -25.05% (p=0.002 n=6)
RandomPfx6Size/1_000_000         114.47Mi ±  0%   85.85Mi ±  0%  -25.00% (p=0.002 n=6)
RandomPfxSize/100                 16.14Ki ± 10%   13.05Ki ± 13%  -19.17% (p=0.002 n=6)
RandomPfxSize/1_000              127.63Ki ±  1%   96.90Ki ±  2%  -24.08% (p=0.002 n=6)
RandomPfxSize/10_000             1228.3Ki ±  0%   920.2Ki ±  0%  -25.08% (p=0.002 n=6)
RandomPfxSize/100_000            11.165Mi ±  0%   8.376Mi ±  0%  -24.98% (p=0.002 n=6)
RandomPfxSize/1_000_000           97.18Mi ±  0%   72.88Mi ±  0%  -25.00% (p=0.002 n=6)
geomean                           1.234Mi         964.6Ki        -23.66%
```