### PR TITLE
Optimize lookups

### DIFF
--- a/key.go
+++ b/key.go
@@ -184,22 +184,18 @@ func (k key) equalFromRoot(o key) bool {
 	return k.len == o.len && k.content == o.content
 }
 
+// Note: using this helps make the compiler inline key.commonPrefixLen
+func minUint8(a, b uint8) uint8 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // commonPrefixLen returns the length of the common prefix between k and
 // o, truncated to the length of the shorter of the two.
-func (k key) commonPrefixLen(o key) uint8 {
-	common := k.content.commonPrefixLen(o.content)
-	// min(l.len, o.len, common)
-	if k.len < o.len {
-		if k.len < common {
-			return k.len
-		}
-		return common
-	} else {
-		if o.len < common {
-			return o.len
-		}
-		return common
-	}
+func (k key) commonPrefixLen(o key) (n uint8) {
+	return k.content.commonPrefixLenTrunc(o.content, minUint8(o.len, k.len))
 }
 
 // isPrefixOf reports whether k has the same content as o up to position k.len.

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,28 @@
+package netipds
+
+// stack is used for depth-first traversals without recursion or heap
+// allocation.
+type stack[T any] struct {
+	data [128]T
+	// top starts at 0, so it is the index of the next available slot.
+	top int
+}
+
+// Push adds an element to the top of the stack. Panics if stack is full.
+func (s *stack[T]) Push(value T) {
+	s.data[s.top] = value
+	s.top++
+}
+
+// IsEmpty reports whether the stack is empty.
+func (s *stack[T]) IsEmpty() bool {
+	return s.top <= 0
+}
+
+// Pop removes and returns the element at the top of the stack. Panics if stack
+// is empty (use IsEmpty()).
+func (s *stack[T]) Pop() T {
+	s.top--
+	value := s.data[s.top]
+	return value
+}

--- a/uint128.go
+++ b/uint128.go
@@ -72,6 +72,20 @@ func (u uint128) commonPrefixLen(v uint128) (n uint8) {
 	return
 }
 
+// commonPrefixLenTrunc compares the first limit bits of u and v, returning the
+// length of their common prefix within that portion.
+func (u uint128) commonPrefixLenTrunc(v uint128, limit uint8) (n uint8) {
+	if n = u64CommonPrefixLen(u.hi, v.hi); limit < n {
+		return limit
+	}
+	if n == 64 {
+		if n += u64CommonPrefixLen(u.lo, v.lo); limit < n {
+			return limit
+		}
+	}
+	return
+}
+
 // func (u *uint128) halves() [2]*uint64 {
 // 	return [2]*uint64{&u.hi, &u.lo}
 // }


### PR DESCRIPTION
These two changes improve lookup time drastically (`PrefixSet.Contains`), cutting it about 80%.