### PR TITLE
Lookup performance optimizations

### DIFF
--- a/key.go
+++ b/key.go
@@ -58,11 +58,11 @@ func (k key) toPrefix() netip.Prefix {
 // bit is used as a selector for a node's children.
 //
 // bitL refers to the left child, and bitR to the right.
-type bit = bool
+type bit = uint8
 
 const (
-	bitL = false
-	bitR = true
+	bitL = 0
+	bitR = 1
 )
 
 var eachBit = [2]bit{bitL, bitR}

--- a/key_test.go
+++ b/key_test.go
@@ -75,17 +75,17 @@ func TestKeyBit(t *testing.T) {
 	tests := []struct {
 		k    key
 		i    uint8
-		want bool
+		want uint8
 	}{
-		{k(uint128{0, 0}, 0, 128), 0, false},
-		{k(uint128{0, 1}, 0, 128), 0, false},
-		{k(uint128{1 << 63, 0}, 0, 128), 0, true},
-		{k(uint128{1 << 62, 0}, 0, 128), 1, true},
-		{k(uint128{0, 1 << 63}, 0, 128), 64, true},
-		{k(uint128{0, 1}, 0, 128), 127, true},
-		{k(uint128{0, 2}, 0, 128), 126, true},
-		{k(uint128{^uint64(0), ^uint64(0)}, 0, 128), 0, true},
-		{k(uint128{^uint64(0), ^uint64(0)}, 0, 128), 127, true},
+		{k(uint128{0, 0}, 0, 128), 0, 0},
+		{k(uint128{0, 1}, 0, 128), 0, 0},
+		{k(uint128{1 << 63, 0}, 0, 128), 0, 1},
+		{k(uint128{1 << 62, 0}, 0, 128), 1, 1},
+		{k(uint128{0, 1 << 63}, 0, 128), 64, 1},
+		{k(uint128{0, 1}, 0, 128), 127, 1},
+		{k(uint128{0, 2}, 0, 128), 126, 1},
+		{k(uint128{^uint64(0), ^uint64(0)}, 0, 128), 0, 1},
+		{k(uint128{^uint64(0), ^uint64(0)}, 0, 128), 127, 1},
 	}
 	for _, tt := range tests {
 		if got := tt.k.bit(tt.i); got != tt.want {

--- a/tree.go
+++ b/tree.go
@@ -541,12 +541,15 @@ func (t *tree[T]) get(k key) (val T, ok bool) {
 
 // contains returns true if this tree includes the exact key provided.
 func (t *tree[T]) contains(k key) (ret bool) {
-	t.walk(k, func(n *tree[T]) bool {
-		if ret = (n.key.equalFromRoot(k) && n.hasEntry); ret {
-			return true
+	n := t
+	for n != nil && n.key.len <= k.len {
+		if !n.key.isZero() {
+			if ret = (n.key.equalFromRoot(k) && n.hasEntry); ret {
+				break
+			}
 		}
-		return false
-	})
+		n = *(n.child(k.bit(n.key.commonPrefixLen(k))))
+	}
 	return
 }
 

--- a/tree.go
+++ b/tree.go
@@ -473,7 +473,7 @@ func (t *tree[T]) insertHole(k key, v T) *tree[T] {
 		bit := k.bit(t.key.len)
 		child, sibling := t.children(bit)
 		if *sibling == nil {
-			*sibling = newTree[T](t.key.next(!bit)).setValue(v)
+			*sibling = newTree[T](t.key.next((^bit) & 1)).setValue(v)
 		}
 		*child = newTree[T](t.key.next(bit)).insertHole(k, v)
 		return t

--- a/tree.go
+++ b/tree.go
@@ -528,8 +528,7 @@ func (t *tree[T]) walk(path key, fn func(*tree[T]) bool) {
 // pathNext returns the child of t which is next in the traversal of the
 // specified path.
 func (t *tree[T]) pathNext(path key) *tree[T] {
-	bit := path.bit(t.key.commonPrefixLen(path))
-	if bit == bitR {
+	if path.bit(t.key.len) == bitR {
 		return t.right
 	}
 	return t.left

--- a/tree.go
+++ b/tree.go
@@ -525,6 +525,16 @@ func (t *tree[T]) walk(path key, fn func(*tree[T]) bool) {
 	}
 }
 
+// pathNext returns the child of t which is next in the traversal of the
+// specified path.
+func (t *tree[T]) pathNext(path key) *tree[T] {
+	bit := path.bit(t.key.commonPrefixLen(path))
+	if bit == bitR {
+		return t.right
+	}
+	return t.left
+}
+
 // get returns the value associated with the exact key provided, if it exists.
 func (t *tree[T]) get(k key) (val T, ok bool) {
 	t.walk(k, func(n *tree[T]) bool {
@@ -541,14 +551,12 @@ func (t *tree[T]) get(k key) (val T, ok bool) {
 
 // contains returns true if this tree includes the exact key provided.
 func (t *tree[T]) contains(k key) (ret bool) {
-	n := t
-	for n != nil && n.key.len <= k.len {
+	for n := t; n != nil; n = n.pathNext(k) {
 		if !n.key.isZero() {
 			if ret = (n.key.equalFromRoot(k) && n.hasEntry); ret {
 				break
 			}
 		}
-		n = *(n.child(k.bit(n.key.commonPrefixLen(k))))
 	}
 	return
 }

--- a/uint128.go
+++ b/uint128.go
@@ -120,10 +120,9 @@ func (u uint128) shiftLeft(n uint8) uint128 {
 
 // isBitSet returns true if the bit at the given position is set.
 // If bit > 127, returns false.
-func (u uint128) isBitSet(bit uint8) bool {
+func (u uint128) isBitSet(bit uint8) uint8 {
 	if bit < 64 {
-		return u.hi&(uint64(1)<<(63-bit)) > 0
-	} else {
-		return u.lo&(uint64(1)<<(127-bit)) > 0
+		return uint8((u.hi >> (63 - bit)) & 1)
 	}
+	return uint8((u.lo >> (127 - bit)) & 1)
 }

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -141,20 +141,20 @@ func TestIsBitSet(t *testing.T) {
 	tests := []struct {
 		a    uint128
 		i    uint8
-		want bool
+		want uint8
 	}{
-		{uint128{0, 0}, 0, false},
-		{uint128{0, 1}, 0, false},
-		{uint128{1 << 63, 0}, 0, true},
-		{uint128{1 << 62, 0}, 1, true},
-		{uint128{0, 1 << 63}, 64, true},
-		{uint128{0, 1}, 127, true},
-		{uint128{0, 2}, 126, true},
-		{uint128{^uint64(0), ^uint64(0)}, 0, true},
-		{uint128{^uint64(0), ^uint64(0)}, 127, true},
+		{uint128{0, 0}, 0, 0},
+		{uint128{0, 1}, 0, 0},
+		{uint128{1 << 63, 0}, 0, 1},
+		{uint128{1 << 62, 0}, 1, 1},
+		{uint128{0, 1 << 63}, 64, 1},
+		{uint128{0, 1}, 127, 1},
+		{uint128{0, 2}, 126, 1},
+		{uint128{^uint64(0), ^uint64(0)}, 0, 1},
+		{uint128{^uint64(0), ^uint64(0)}, 127, 1},
 
 		// i > 127 => false
-		{uint128{0, 0}, 128, false},
+		{uint128{0, 0}, 128, 0},
 	}
 	for _, tt := range tests {
 		if got := tt.a.isBitSet(tt.i); got != tt.want {


### PR DESCRIPTION
The biggest change is inlining the tree traversal logic (currently, only for `tree.contains`). This is the most impactful change here.

Also: change `bit` type from `bool` to `uint8`. This allows for some branch elimination.

This PR reduces lookup time by 64%, according to iprbench.